### PR TITLE
Implementation ecc mul var

### DIFF
--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -48,7 +48,7 @@ pub trait GeneralEccInstruction<Emulated: CurveAffine, N: FieldExt> {
         offset: &mut usize,
     ) -> Result<AssignedPoint<N>, Error>;
 
-    fn double(&self, region: &mut Region<'_, N>, p: AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
+    fn double(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
 
     fn negate(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
 
@@ -208,8 +208,8 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
         self._add(region, p0, p1, offset)
     }
 
-    fn double(&self, region: &mut Region<'_, N>, p: AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {
-        unimplemented!();
+    fn double(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {
+        self._add(region, p, p, offset)
     }
 
     fn negate(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {

--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -50,6 +50,8 @@ pub trait GeneralEccInstruction<Emulated: CurveAffine, N: FieldExt> {
 
     fn double(&self, region: &mut Region<'_, N>, p: AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
 
+    fn negate(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error>;
+
     fn mul_var(
         &self,
         region: &mut Region<'_, N>,
@@ -208,6 +210,14 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
 
     fn double(&self, region: &mut Region<'_, N>, p: AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {
         unimplemented!();
+    }
+
+    fn negate(&self, region: &mut Region<'_, N>, p: &AssignedPoint<N>, offset: &mut usize) -> Result<AssignedPoint<N>, Error> {
+        use crate::rns::{fe_to_big};
+        use num_bigint::BigUint as big_uint;
+        let main_gate = self.main_gate();
+        let integer_chip = self.base_field_chip();
+        Ok(AssignedPoint::new(p.x.clone(), p.y.clone(), p.z.clone()))
     }
 
     fn mul_var(

--- a/src/circuit/ecc/general_ecc.rs
+++ b/src/circuit/ecc/general_ecc.rs
@@ -56,7 +56,8 @@ pub trait GeneralEccInstruction<Emulated: CurveAffine, N: FieldExt> {
         &self,
         region: &mut Region<'_, N>,
         p: AssignedPoint<N>,
-        e: AssignedInteger<Emulated::ScalarExt>,
+        // FIXME: e: AssignedInteger<Emulated::ScalarExt>,
+        e: AssignedInteger<N>,
         offset: &mut usize,
     ) -> Result<AssignedPoint<N>, Error>;
 
@@ -77,6 +78,7 @@ pub struct GeneralEccChip<Emulated: CurveAffine, F: FieldExt> {
 
 // Ecc operation mods
 mod add;
+mod mul;
 
 impl<Emulated: CurveAffine, N: FieldExt> GeneralEccChip<Emulated, N> {
     pub (super) fn new(
@@ -224,10 +226,11 @@ impl<Emulated: CurveAffine, N: FieldExt> GeneralEccInstruction<Emulated, N> for 
         &self,
         region: &mut Region<'_, N>,
         p: AssignedPoint<N>,
-        e: AssignedInteger<Emulated::ScalarExt>,
+        // FIXME: e: AssignedInteger<Emulated::ScalarExt>,
+        e: AssignedInteger<N>,
         offset: &mut usize,
     ) -> Result<AssignedPoint<N>, Error> {
-        unimplemented!();
+        self._mul_var(region, p, e, offset)
     }
 
     fn mul_fix(

--- a/src/circuit/ecc/general_ecc/mul.rs
+++ b/src/circuit/ecc/general_ecc/mul.rs
@@ -1,0 +1,168 @@
+use super::AssignedPoint;
+use crate::circuit::ecc::general_ecc::{GeneralEccChip, GeneralEccInstruction};
+use crate::circuit::integer::{IntegerChip, IntegerInstructions};
+use crate::circuit::main_gate::{CombinationOption, MainGateColumn, MainGateInstructions, Term};
+use crate::circuit::{Assigned, AssignedCondition, AssignedInteger, AssignedValue, UnassignedValue};
+use crate::rns::{big_to_fe, fe_to_big};
+use crate::{BIT_LEN_LIMB, NUMBER_OF_LIMBS};
+use halo2::arithmetic::{CurveAffine, FieldExt};
+use halo2::circuit::Region;
+use halo2::plonk::Error;
+use num_bigint::BigUint as big_uint;
+
+struct ScalarTuple<F: FieldExt> {
+    h: AssignedValue<F>,
+    l: AssignedValue<F>,
+}
+
+struct BitHelper<F: FieldExt> {
+    bits: ScalarTuple<F>,
+    carry: AssignedValue<F>,
+}
+
+impl<Emulated: CurveAffine, F: FieldExt> GeneralEccChip<Emulated, F> {
+    fn decompose(
+        &self,
+        region: &mut Region<'_, F>,
+        // FIXME: input: AssignedInteger<Emulated::ScalarExt>,
+        input: AssignedInteger<F>,
+        offset: &mut usize,
+    ) -> Result<Vec<ScalarTuple<F>>, Error> {
+        let zero = big_uint::from(0 as u64);
+        let one = big_uint::from(1 as u64);
+        let two = big_uint::from(2 as u64);
+        let four = big_uint::from(4 as u64);
+
+        let main_gate = self.main_gate();
+        let mut res = Vec::with_capacity(NUMBER_OF_LIMBS * BIT_LEN_LIMB / 2);
+        let mut d = zero.clone();
+        let mut carry_bits = [zero.clone(), zero.clone(), zero.clone(), zero.clone()];
+
+        // check that x == 0 or x == 1
+        let range_check = |region: &mut Region<'_, F>, assigned: AssignedValue<F>, offset: &mut usize| -> Result<(), Error> {
+            main_gate.assert_bit(region, assigned, offset)?;
+            Ok(())
+        };
+
+        for idx in 0..NUMBER_OF_LIMBS {
+            d = d + match input.limb(idx).value() {
+                Some(v) => fe_to_big(v),
+                _ => zero.clone(),
+            };
+
+            for _ in 0..(BIT_LEN_LIMB / 2) {
+                let current = Term::Unassigned(Some(big_to_fe(d.clone())), -F::from_u64(1));
+                let mut a = zero.clone();
+                let mut b = zero.clone();
+                let mut carry = zero.clone();
+
+                if d > zero {
+                    let rem = &d % &four;
+                    a = ((&rem) & (&two)) >> 1;
+                    b = (&rem) & (&one);
+                    carry = (&a) & (&b);
+                    d = d - &rem + &four * &carry;
+                    d = d / &four;
+                }
+
+                let a_f = big_to_fe(a);
+                let b_f = big_to_fe(b);
+                let carry_f = big_to_fe(carry);
+
+                // 2a+b-4carry+4d_next = d
+                let (cell_a, cell_b, cell_c, _) = main_gate.combine(
+                    region,
+                    Term::Unassigned(Some(a_f), F::from_u64(2)),
+                    Term::Unassigned(Some(b_f), F::from_u64(1)),
+                    Term::Unassigned(Some(carry_f), -F::from_u64(4)),
+                    current,
+                    F::zero(),
+                    offset,
+                    CombinationOption::CombineToNextAdd(F::from_u64(4)),
+                )?;
+
+                res.push(BitHelper {
+                    bits: ScalarTuple {
+                        h: AssignedValue::new(cell_a, Some(a_f)),
+                        l: AssignedValue::new(cell_b, Some(b_f)),
+                    },
+                    carry: AssignedValue::new(cell_c, Some(carry_f)),
+                })
+            }
+
+            carry_bits[idx] = d.clone();
+        }
+
+        for idx in 0..NUMBER_OF_LIMBS {
+            let assigned = main_gate.assign_value(
+                region,
+                &UnassignedValue::new(Some(big_to_fe(carry_bits[idx].clone()))),
+                MainGateColumn::A,
+                offset,
+            )?;
+            main_gate.assert_bit(region, assigned, offset)?;
+        }
+
+        for x in res.iter() {
+            range_check(region, x.bits.h.clone(), offset)?;
+            range_check(region, x.bits.l.clone(), offset)?;
+
+            // a==1 & b==1 <=> carry == 1
+            main_gate.combine(
+                region,
+                Term::Assigned(&x.bits.h, F::zero()),
+                Term::Assigned(&x.bits.l, F::zero()),
+                Term::Assigned(&x.carry, -F::one()),
+                Term::Zero,
+                F::zero(),
+                offset,
+                CombinationOption::SingleLinerMul,
+            )?;
+        }
+
+        Ok(res.into_iter().map(|kv| kv.bits).collect())
+    }
+
+    pub fn create_identity_point(&self, region: &mut Region<'_, F>, offset: &mut usize) -> Result<AssignedPoint<F>, Error> {
+        let main_gate = self.main_gate();
+        let base_chip = self.base_field_chip();
+
+        let z = base_chip.rns.new_from_big(0u32.into());
+        let z = base_chip.assign_integer(region, Some(z), offset)?;
+        let c = main_gate.assign_bit(region, Some(F::one()), offset)?;
+        Ok(AssignedPoint::new(z.clone(), z, c))
+    }
+
+    pub(crate) fn _mul_var(
+        &self,
+        region: &mut Region<'_, F>,
+        p: AssignedPoint<F>,
+        // FIXME: e: AssignedInteger<Emulated::ScalarExt>,
+        e: AssignedInteger<F>,
+        offset: &mut usize,
+    ) -> Result<AssignedPoint<F>, Error> {
+        let main_gate = self.main_gate();
+
+        let p_neg = self.negate(region, &p, offset)?;
+        let p_double = self.double(region, &p, offset)?;
+        let selector = self.decompose(region, e, offset)?;
+
+        let mut point = self.create_identity_point(region, offset)?;
+
+        for di in selector.iter().rev() {
+            let a_is_zero = main_gate.is_zero(region, di.h.clone(), offset)?;
+            let b_is_zero = main_gate.is_zero(region, di.l.clone(), offset)?;
+            let b_is_not_zero = main_gate.cond_not(region, &b_is_zero, offset)?;
+            let b1 = self.select_or_assign(region, &b_is_not_zero, &p, Emulated::identity(), offset)?;
+            let b2 = self.select(region, &b_is_zero, &p_double, &p_neg, offset)?;
+            let a = self.select(region, &a_is_zero, &b1, &b2, offset)?;
+
+            // each iter handles 2bits
+            point = self.double(region, &point, offset)?;
+            point = self.double(region, &point, offset)?;
+            point = self.add(region, &point, &a, offset)?;
+        }
+
+        Ok(point)
+    }
+}

--- a/src/circuit/integer.rs
+++ b/src/circuit/integer.rs
@@ -20,6 +20,7 @@ mod mul;
 mod reduce;
 mod square;
 mod sub;
+mod neg;
 
 #[derive(Clone, Debug)]
 pub struct IntegerConfig {
@@ -44,6 +45,7 @@ pub trait IntegerInstructions<N: FieldExt> {
     fn add(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn add_constant(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &Integer<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn sub(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
+    fn neg(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn mul(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn square(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error>;
     fn div(
@@ -91,6 +93,10 @@ impl<W: FieldExt, N: FieldExt> IntegerInstructions<N> for IntegerChip<W, N> {
 
     fn sub(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {
         self._sub(region, a, b, offset)
+    }
+
+    fn neg(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {
+        self._neg(region, a, offset)
     }
 
     fn mul(&self, region: &mut Region<'_, N>, a: &AssignedInteger<N>, b: &AssignedInteger<N>, offset: &mut usize) -> Result<AssignedInteger<N>, Error> {

--- a/src/circuit/integer/neg.rs
+++ b/src/circuit/integer/neg.rs
@@ -1,0 +1,35 @@
+use super::IntegerChip;
+use crate::circuit::main_gate::MainGateInstructions;
+use crate::circuit::{AssignedInteger, AssignedLimb};
+use crate::rns::{Common, fe_to_big};
+use crate::NUMBER_OF_LIMBS;
+use halo2::arithmetic::FieldExt;
+use halo2::circuit::Region;
+use halo2::plonk::Error;
+
+impl<W: FieldExt, N: FieldExt> IntegerChip<W, N> {
+    pub(crate) fn _neg(
+        &self,
+        region: &mut Region<'_, N>,
+        a: &AssignedInteger<N>,
+        offset: &mut usize,
+    ) -> Result<AssignedInteger<N>, Error> {
+        let main_gate = self.main_gate();
+
+        let aux: Vec<N> = self.rns.aux.limbs();
+        let aux_native = self.rns.aux.native();
+        let mut b_limbs: Vec<AssignedLimb<N>> = Vec::with_capacity(NUMBER_OF_LIMBS);
+
+        for idx in 0..NUMBER_OF_LIMBS {
+            let a_limb = a.limb(idx);
+            let aux = aux[idx];
+            let b_limb = main_gate.neg_with_constant(region, a_limb, aux, offset)?;
+
+            b_limbs.push(AssignedLimb::<N>::new(b_limb.cell, b_limb.value, fe_to_big(aux)))
+        }
+
+        let b_native = main_gate.neg_with_constant(region, a.native(), aux_native, offset)?;
+
+        Ok(AssignedInteger::new(b_limbs, b_native))
+    }
+}

--- a/src/circuit/main_gate.rs
+++ b/src/circuit/main_gate.rs
@@ -38,6 +38,7 @@ pub enum CombinationOption<F: FieldExt> {
     SingleLinerMul,
     SingleLinerAdd,
     CombineToNextMul(F),
+    CombineToNextMulN(F, F),
     CombineToNextAdd(F),
 }
 
@@ -192,6 +193,14 @@ pub trait MainGateInstructions<F: FieldExt> {
         offset: &mut usize,
     ) -> Result<AssignedValue<F>, Error>;
 
+    fn neg_with_constant(
+        &self,
+        region: &mut Region<'_, F>,
+        a: impl Assigned<F>,
+        aux: F,
+        offset: &mut usize,
+    ) -> Result<AssignedValue<F>, Error>;
+
     fn mul(&self, region: &mut Region<'_, F>, a: impl Assigned<F>, b: impl Assigned<F>, offset: &mut usize) -> Result<AssignedValue<F>, Error>;
 
     fn no_operation(&self, region: &mut Region<'_, F>, offset: &mut usize) -> Result<(), Error>;
@@ -262,6 +271,34 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
             Term::Unassigned(c, -one),
             Term::Zero,
             constant,
+            offset,
+            CombinationOption::SingleLinerAdd,
+        )?;
+
+        Ok(AssignedValue::new(cell, c))
+    }
+
+    fn neg_with_constant(
+        &self,
+        region: &mut Region<'_, F>,
+        a: impl Assigned<F>,
+        aux: F,
+        offset: &mut usize,
+    ) -> Result<AssignedValue<F>, Error> {
+        let c = match a.value() {
+            Some(a) => Some(-a + aux),
+            _ => None,
+        };
+
+        let one = F::one();
+
+        let (_, _, cell, _) = self.combine(
+            region,
+            Term::Assigned(&a, -one),
+            Term::Zero,
+            Term::Unassigned(c, -one),
+            Term::Zero,
+            aux,
             offset,
             CombinationOption::SingleLinerAdd,
         )?;
@@ -865,6 +902,7 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
 
         Ok(())
     }
+
     fn combine(
         &self,
         region: &mut Region<'_, F>,
@@ -896,6 +934,10 @@ impl<F: FieldExt> MainGateInstructions<F> for MainGate<F> {
         match option {
             CombinationOption::CombineToNextMul(base) => {
                 region.assign_fixed(|| "s_mul", self.config.s_mul, *offset, || Ok(F::one()))?;
+                region.assign_fixed(|| "sd_next", self.config.sd_next, *offset, || Ok(base))?;
+            }
+            CombinationOption::CombineToNextMulN(base, n) => {
+                region.assign_fixed(|| "s_mul", self.config.s_mul, *offset, || Ok(n))?;
                 region.assign_fixed(|| "sd_next", self.config.sd_next, *offset, || Ok(base))?;
             }
             CombinationOption::CombineToNextAdd(base) => {


### PR DESCRIPTION
We use variant w-naf (with w = 2) to implement ecc mul which needs 256 * (3 / 2) ecc add.
Here is an example of `p * s`.
At first, we decompose `s` into 2-bit vector with a carry bit.
Suppose `s mod 4 = bit_low + bit_high * 2`.
Unlike normal binary decompose, when we meet 0b11, it doesn't means 3 but (-1). So the constraints looks like,
`bit_low + bit_high * 2 - 4 * bit_low * bit_high + 4 * s' = s`.
At last, `carry = s_final`.

Then we iterate all 2-bit pairs from most significant pair.
```
acc = carry ? p : identity;
for pair of pairs {
  s = match pair {
    0b00 => identity,
    0b01 => p,
    0b10 => p + p,
    0b11 => -p
  }
  acc = acc * 4 + s
}
```
